### PR TITLE
Harden CI: add Python 3.13, pip cache, black check, pin deps

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,7 +11,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: ["3.11", "3.12"]
+        python-version: ["3.11", "3.12", "3.13"]
 
     steps:
       - name: Checkout repository
@@ -26,6 +26,7 @@ jobs:
         uses: actions/setup-python@v5
         with:
           python-version: ${{ matrix.python-version }}
+          cache: 'pip'
 
       - name: Install dependencies
         run: |
@@ -34,6 +35,9 @@ jobs:
 
       - name: Lint
         run: ruff check .
+
+      - name: Format check
+        run: black --check .
 
       - name: Test
         run: pytest

--- a/espansr/__main__.py
+++ b/espansr/__main__.py
@@ -56,9 +56,7 @@ def cmd_list(args) -> int:
 
     if not triggered:
         print("No templates with triggers found.")
-        print(
-            "Add a 'trigger' field (e.g. ':foo') to a template JSON to include it in sync."
-        )
+        print("Add a 'trigger' field (e.g. ':foo') to a template JSON to include it in sync.")
         return 0
 
     print(f"{'TRIGGER':<22} TEMPLATE NAME")
@@ -143,15 +141,11 @@ def main() -> None:
     subparsers.add_parser("sync", help="Sync templates to Espanso match file")
     subparsers.add_parser("status", help="Show Espanso process status and config path")
     subparsers.add_parser("list", help="List templates with triggers")
-    subparsers.add_parser(
-        "validate", help="Validate templates for Espanso compatibility"
-    )
+    subparsers.add_parser("validate", help="Validate templates for Espanso compatibility")
     import_parser = subparsers.add_parser(
         "import", help="Import template(s) from a file or directory"
     )
-    import_parser.add_argument(
-        "path", help="Path to a JSON file or directory of JSON files"
-    )
+    import_parser.add_argument("path", help="Path to a JSON file or directory of JSON files")
     subparsers.add_parser("gui", help="Launch the GUI")
 
     args = parser.parse_args()

--- a/espansr/core/config.py
+++ b/espansr/core/config.py
@@ -144,9 +144,7 @@ class Config:
 
         return cls(
             espanso=(
-                EspansoConfig(
-                    **{k: v for k, v in espanso_data.items() if k in known_espanso}
-                )
+                EspansoConfig(**{k: v for k, v in espanso_data.items() if k in known_espanso})
                 if espanso_data
                 else EspansoConfig()
             ),

--- a/espansr/core/templates.py
+++ b/espansr/core/templates.py
@@ -211,9 +211,7 @@ class TemplateManager:
         config = get_config()
         return config.ui.max_template_versions
 
-    def create_version(
-        self, template: Template, note: str = ""
-    ) -> Optional[TemplateVersion]:
+    def create_version(self, template: Template, note: str = "") -> Optional[TemplateVersion]:
         """Create a new version snapshot of a template."""
         version_dir = self._get_version_dir(template)
 
@@ -253,9 +251,7 @@ class TemplateManager:
 
         return sorted(versions, key=lambda v: v.version)
 
-    def get_version(
-        self, template: Template, version_num: int
-    ) -> Optional[TemplateVersion]:
+    def get_version(self, template: Template, version_num: int) -> Optional[TemplateVersion]:
         """Get a specific version of a template."""
         version_dir = self._get_version_dir(template)
         version_path = version_dir / f"v{version_num}.json"
@@ -280,9 +276,7 @@ class TemplateManager:
             return None
 
         if create_backup:
-            self.create_version(
-                template, note=f"Backup before revert to v{version_num}"
-            )
+            self.create_version(template, note=f"Backup before revert to v{version_num}")
 
         restored = Template.from_dict(version.template_data, path=template._path)
 
@@ -608,9 +602,7 @@ def _deduplicate_name(name: str, manager: TemplateManager) -> tuple[str, bool]:
         counter += 1
 
 
-def import_template(
-    path: Path, manager: Optional[TemplateManager] = None
-) -> ImportResult:
+def import_template(path: Path, manager: Optional[TemplateManager] = None) -> ImportResult:
     """Import a single JSON template file.
 
     Loads the file, strips unrecognized fields, de-duplicates the name against
@@ -660,9 +652,7 @@ def import_template(
     return ImportResult(template=template, renamed=was_renamed)
 
 
-def import_templates(
-    directory: Path, manager: Optional[TemplateManager] = None
-) -> ImportSummary:
+def import_templates(directory: Path, manager: Optional[TemplateManager] = None) -> ImportSummary:
     """Import all JSON template files from a directory.
 
     Args:

--- a/espansr/integrations/espanso.py
+++ b/espansr/integrations/espanso.py
@@ -317,18 +317,14 @@ def sync_to_espanso() -> bool:
     matches = []
 
     for template in template_manager.iter_with_triggers():
-        replace_text = _convert_to_espanso_placeholders(
-            template.content, template.variables or []
-        )
+        replace_text = _convert_to_espanso_placeholders(template.content, template.variables or [])
         match_entry: dict = {
             "trigger": template.trigger,
             "replace": replace_text,
         }
 
         if template.variables:
-            match_entry["vars"] = [
-                _build_espanso_var_entry(var) for var in template.variables
-            ]
+            match_entry["vars"] = [_build_espanso_var_entry(var) for var in template.variables]
 
         matches.append(match_entry)
 
@@ -382,9 +378,7 @@ def _restart_espanso_wsl2() -> None:
         if result.returncode == 0:
             print("Espanso restarted successfully.")
         else:
-            print(
-                "Note: Run 'espanso restart' from Windows PowerShell to reload triggers."
-            )
+            print("Note: Run 'espanso restart' from Windows PowerShell to reload triggers.")
     except Exception:
         print("Note: Run 'espanso restart' from Windows PowerShell to reload triggers.")
 
@@ -451,9 +445,7 @@ class EspansoManager:
             }
 
             if template.variables:
-                match_entry["vars"] = [
-                    _build_espanso_var_entry(var) for var in template.variables
-                ]
+                match_entry["vars"] = [_build_espanso_var_entry(var) for var in template.variables]
 
             matches.append(match_entry)
 

--- a/espansr/ui/main_window.py
+++ b/espansr/ui/main_window.py
@@ -91,12 +91,8 @@ class MainWindow(QMainWindow):
         self._browser.template_selected.connect(self._editor.load_template)
         self._browser.new_template_requested.connect(self._editor.clear)
         self._editor.template_saved.connect(self._on_template_saved)
-        self._browser.status_message.connect(
-            lambda msg, ms: status_bar.showMessage(msg, ms)
-        )
-        self._editor.status_message.connect(
-            lambda msg, ms: status_bar.showMessage(msg, ms)
-        )
+        self._browser.status_message.connect(lambda msg, ms: status_bar.showMessage(msg, ms))
+        self._editor.status_message.connect(lambda msg, ms: status_bar.showMessage(msg, ms))
 
     def _apply_theme(self) -> None:
         """Apply the configured theme stylesheet."""

--- a/espansr/ui/template_browser.py
+++ b/espansr/ui/template_browser.py
@@ -202,9 +202,7 @@ class TemplateBrowserWidget(QWidget):
             return item
 
         # Root-level templates
-        for template in sorted(
-            templates_by_folder.get("", []), key=lambda t: t.name.lower()
-        ):
+        for template in sorted(templates_by_folder.get("", []), key=lambda t: t.name.lower()):
             self.tree.addTopLevelItem(_make_item(template))
 
         # Folders
@@ -212,9 +210,7 @@ class TemplateBrowserWidget(QWidget):
             folder_item = QTreeWidgetItem([folder])
             folder_item.setData(0, Qt.ItemDataRole.UserRole, None)
             folder_item.setExpanded(True)
-            for template in sorted(
-                templates_by_folder[folder], key=lambda t: t.name.lower()
-            ):
+            for template in sorted(templates_by_folder[folder], key=lambda t: t.name.lower()):
                 folder_item.addChild(_make_item(template))
             self.tree.addTopLevelItem(folder_item)
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,5 +1,5 @@
 [build-system]
-requires = ["setuptools>=65", "wheel"]
+requires = ["setuptools>=65,<76", "wheel"]
 build-backend = "setuptools.build_meta"
 
 [project]
@@ -9,16 +9,16 @@ description = "Espanso text expansion template manager"
 readme = "README.md"
 requires-python = ">=3.11"
 dependencies = [
-    "PyYAML>=6.0",
-    "PyQt6>=6.6",
+    "PyYAML>=6.0,<7",
+    "PyQt6>=6.6,<7",
 ]
 
 [project.optional-dependencies]
 dev = [
-    "pytest>=8.0",
-    "pytest-qt>=4.4",
-    "ruff>=0.4",
-    "black>=24.0",
+    "pytest>=8.0,<9",
+    "pytest-qt>=4.4,<5",
+    "ruff>=0.4,<1",
+    "black>=24.0,<25",
 ]
 
 [project.scripts]
@@ -37,7 +37,9 @@ line-length = 100
 
 [tool.ruff.lint]
 select = ["E", "F", "W", "I"]
-ignore = ["E501"]
 
 [tool.pytest.ini_options]
 testpaths = ["tests"]
+
+[tool.black]
+line-length = 100

--- a/tests/test_espanso.py
+++ b/tests/test_espanso.py
@@ -251,9 +251,7 @@ def test_platform_detection_wsl2():
 
     with (
         patch("platform.system", return_value="Linux"),
-        patch(
-            "builtins.open", mock_open(read_data="Linux version 5.15 (Microsoft WSL2)")
-        ),
+        patch("builtins.open", mock_open(read_data="Linux version 5.15 (Microsoft WSL2)")),
     ):
         import espansr.core.config as cfg_mod
 
@@ -269,9 +267,7 @@ def test_platform_detection_native_linux():
 
     with (
         patch("platform.system", return_value="Linux"),
-        patch(
-            "builtins.open", mock_open(read_data="Linux version 5.15 generic ubuntu")
-        ),
+        patch("builtins.open", mock_open(read_data="Linux version 5.15 generic ubuntu")),
     ):
         import espansr.core.config as cfg_mod
 

--- a/tests/test_gui_single_screen.py
+++ b/tests/test_gui_single_screen.py
@@ -36,9 +36,7 @@ def _make_window(qtbot, config, tm=None, match_dir=None, tmp_path=None):
     )
 
     with contextlib.ExitStack() as stack:
-        stack.enter_context(
-            patch("espansr.ui.main_window.get_config", return_value=config)
-        )
+        stack.enter_context(patch("espansr.ui.main_window.get_config", return_value=config))
         stack.enter_context(patch("espansr.ui.main_window.get_config_manager"))
         stack.enter_context(patch("espansr.ui.template_browser.get_config"))
         stack.enter_context(patch("espansr.ui.template_editor.get_config"))

--- a/tests/test_path_consolidation.py
+++ b/tests/test_path_consolidation.py
@@ -312,8 +312,7 @@ def test_clean_stale_silent_on_permission_error(tmp_path, caplog):
 
     # Should have logged a warning
     assert any(
-        "permission" in record.message.lower()
-        or "access denied" in record.message.lower()
+        "permission" in record.message.lower() or "access denied" in record.message.lower()
         for record in caplog.records
     )
 

--- a/tests/test_validate.py
+++ b/tests/test_validate.py
@@ -53,9 +53,7 @@ def test_error_on_empty_trigger():
     result = validate_template(t)
     errors = [w for w in result if w.severity == "error"]
     assert len(errors) >= 1
-    assert any(
-        "empty" in w.message.lower() or "trigger" in w.message.lower() for w in errors
-    )
+    assert any("empty" in w.message.lower() or "trigger" in w.message.lower() for w in errors)
 
 
 def test_error_on_short_trigger():
@@ -175,9 +173,7 @@ def test_validate_all_detects_duplicate_triggers():
         mock_mgr.return_value.iter_with_triggers.return_value = iter(templates)
         result = validate_all()
 
-    errors = [
-        w for w in result if w.severity == "error" and "duplicate" in w.message.lower()
-    ]
+    errors = [w for w in result if w.severity == "error" and "duplicate" in w.message.lower()]
     assert len(errors) >= 1
     assert any(":dup" in w.message for w in errors)
 
@@ -265,9 +261,7 @@ def test_sync_proceeds_with_warnings_only(tmp_path):
     from espansr.integrations.validate import ValidationWarning
 
     fake_warnings = [
-        ValidationWarning(
-            severity="warning", message="trigger missing prefix", template_name="t"
-        ),
+        ValidationWarning(severity="warning", message="trigger missing prefix", template_name="t"),
     ]
 
     match_dir = tmp_path / "match"


### PR DESCRIPTION
## What changed

- Added Python 3.13 to the CI matrix (3.11, 3.12, 3.13)
- Enabled pip caching in actions/setup-python
- Added `black --check .` to CI
- Pinned dependencies with upper-bound major caps in `pyproject.toml`
- Added `[tool.black]` config with `line-length = 100`
- Removed no-op Ruff ignore (`E501`)
- Auto-formatted 10 files with Black to satisfy the new CI check

## Why

This completes the next roadmap item: **CI Hardening**, and prepares the project for v1.0 release readiness.

## How to verify

- `ruff check .`
- `black --check .`
- `QT_QPA_PLATFORM=offscreen pytest`

All checks passed locally (`141 passed`).

## Files changed

- CI workflow: `.github/workflows/ci.yml`
- Project config: `pyproject.toml`
- Formatting-only updates in 10 source/test files
