### PR TITLE
fix: Espanso triggers fire over RustDesk/RDP (win32_exclude_orphan_events)

### DIFF
--- a/espansr/integrations/espanso.py
+++ b/espansr/integrations/espanso.py
@@ -855,18 +855,23 @@ def restart_espanso() -> bool:
 
 
 # ── Section 6: Remote-desktop (RustDesk/RDP) reliability ──────────────────────
-# Over RustDesk/RDP, Espanso's simulated-keystroke injection garbles keys so
-# triggers like :coms fail to expand. The Windows-appropriate fix is to switch
-# Espanso to the clipboard backend (paste instead of per-key injection) and add
-# small delays. This mirrors what install.sh does for Linux/Wayland (forcing the
-# X11 path), but here the lever is Espanso's own config/default.yml. The keys
-# below are espansr-managed and reversible via the --revert path.
+# Over RustDesk/RDP the keys you type are *software-injected* on the host with no
+# physical HID source. Espanso's default `win32_exclude_orphan_events: true`
+# discards exactly those events, so triggers like :coms are never even detected.
+# Setting it false lets Espanso see RustDesk/RDP input — this is THE fix for
+# "commands don't fire over RustDesk." We also switch to the clipboard backend so
+# text expansions paste cleanly instead of garbling, and quiet the tray. Mirrors
+# install.sh's Linux/Wayland fix; here the lever is Espanso's config/default.yml.
+# All keys are espansr-managed and reversible via the --revert path.
 REMOTE_DESKTOP_MARKER = (
     "# espansr-remote-desktop — managed by espansr; "
     "revert with: espansr configure-remote-desktop --revert"
 )
 _REMOTE_DESKTOP_KEYS: dict = {
-    "backend": "Clipboard",  # primary fix: paste instead of per-key injection
+    # Detection: stop espanso from filtering out RustDesk/RDP-injected keystrokes.
+    "win32_exclude_orphan_events": False,
+    # Injection: paste expansions instead of per-key typing (clean over remote).
+    "backend": "Clipboard",
     "show_icon": False,
     "show_notifications": False,
     "key_delay": 30,

--- a/tests/test_remote_desktop_config.py
+++ b/tests/test_remote_desktop_config.py
@@ -30,6 +30,7 @@ def test_apply_writes_remote_desktop_keys(tmp_path):
 
     text = _default_yml(cfg).read_text(encoding="utf-8")
     data = yaml.safe_load(text)
+    assert data["win32_exclude_orphan_events"] is False
     assert data["backend"] == "Clipboard"
     assert data["show_icon"] is False
     assert data["show_notifications"] is False


### PR DESCRIPTION
## Root cause (validated live)
Over RustDesk/RDP, the keys you type are **software-injected** on the host with no
physical HID source. Espanso's default `win32_exclude_orphan_events: true` filters
out exactly those events, so triggers like `:coms` were **never detected**. The
earlier `backend: Clipboard` change only affected text *injection* (the output
direction) and so could not help shell triggers (`:coms`/`:aopen`) or detection at
all — which is why the first attempt didn't work.

## Fix
Add `win32_exclude_orphan_events: false` to the espansr-managed remote-desktop keys
in `apply_remote_desktop_config`, so `espansr configure-remote-desktop` (run by
`install.ps1`) lets Espanso see remote-desktop input. `backend: Clipboard` is
retained so text expansions still paste cleanly over the link. Reversible via
`espansr configure-remote-desktop --revert`.

**Verified live over RustDesk** on a host workstation: after applying + restarting
Espanso, `:coms` now fires.

## Testing
- 571 tests pass; `ruff` + `black` clean.
- `tests/test_remote_desktop_config.py` updated to assert the new key.

## Rollout
Other machines pick this up on their next `install.ps1` run / `espansr sync`
(re-run applies the new key and restarts Espanso).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
